### PR TITLE
phmap.h header; included missing `atomic` header

### DIFF
--- a/parallel_hashmap/phmap.h
+++ b/parallel_hashmap/phmap.h
@@ -45,6 +45,7 @@
 #include <utility>
 #include <array>
 #include <cassert>
+#include <atomic>
 
 #include "phmap_utils.h"
 #include "phmap_base.h"


### PR DESCRIPTION
Missing header was causing a compilation error in some cases where the parent application including the library does not include `atomic` before including phmap header