### PR TITLE
Cleanup deprecation warning for c++17 found in vs2019

### DIFF
--- a/parallel_hashmap/btree.h
+++ b/parallel_hashmap/btree.h
@@ -713,7 +713,7 @@ namespace phmap {
         template <
             typename Compare, typename K, typename LK,
             phmap::enable_if_t<!std::is_same<bool, phmap::invoke_result_t<
-                                                       Compare(const K &, const LK &)>>::value,
+                                                       Compare, const K &, const LK &>>::value,
                                int> = 0>
             constexpr phmap::weak_ordering do_three_way_comparison(const Compare &compare,
                                                                    const K &x, const LK &y) {
@@ -721,8 +721,8 @@ namespace phmap {
         }
         template <
             typename Compare, typename K, typename LK,
-            phmap::enable_if_t<std::is_same<bool, phmap::invoke_result_t<Compare(
-            const K &, const LK &)>>::value,
+            phmap::enable_if_t<std::is_same<bool, phmap::invoke_result_t<Compare,
+            const K &, const LK &>>::value,
                                int> = 0>
             constexpr phmap::weak_ordering do_three_way_comparison(const Compare &compare,
                                                                    const K &x, const LK &y) {

--- a/parallel_hashmap/btree.h
+++ b/parallel_hashmap/btree.h
@@ -712,7 +712,7 @@ namespace phmap {
 
         template <
             typename Compare, typename K, typename LK,
-            phmap::enable_if_t<!std::is_same<bool, phmap::result_of_t<
+            phmap::enable_if_t<!std::is_same<bool, phmap::invoke_result_t<
                                                        Compare(const K &, const LK &)>>::value,
                                int> = 0>
             constexpr phmap::weak_ordering do_three_way_comparison(const Compare &compare,
@@ -721,7 +721,7 @@ namespace phmap {
         }
         template <
             typename Compare, typename K, typename LK,
-            phmap::enable_if_t<std::is_same<bool, phmap::result_of_t<Compare(
+            phmap::enable_if_t<std::is_same<bool, phmap::invoke_result_t<Compare(
             const K &, const LK &)>>::value,
                                int> = 0>
             constexpr phmap::weak_ordering do_three_way_comparison(const Compare &compare,
@@ -743,7 +743,7 @@ namespace container_internal {
     // comparator.
     template <typename Compare, typename T>
     using btree_is_key_compare_to =
-        std::is_convertible<phmap::result_of_t<Compare(const T &, const T &)>,
+        std::is_convertible<phmap::invoke_result_t<Compare, const T &, const T &>,
                             phmap::weak_ordering>;
 
     struct StringBtreeDefaultLess {
@@ -2507,7 +2507,7 @@ namespace container_internal {
 
         // Verify that key_compare returns an phmap::{weak,strong}_ordering or bool.
         using compare_result_type =
-            phmap::result_of_t<key_compare(key_type, key_type)>;
+            phmap::invoke_result_t<key_compare, key_type, key_type>;
         static_assert(
             std::is_same<compare_result_type, bool>::value ||
             std::is_convertible<compare_result_type, phmap::weak_ordering>::value,

--- a/parallel_hashmap/phmap_base.h
+++ b/parallel_hashmap/phmap_base.h
@@ -328,8 +328,12 @@ using common_type_t = typename std::common_type<T...>::type;
 template <typename T>
 using underlying_type_t = typename std::underlying_type<T>::type;
 
-template <typename T>
-using result_of_t = typename std::result_of<T>::type;
+template< class F, class... ArgTypes>
+#if __cplusplus >= 201703L
+using invoke_result_t = typename std::invoke_result_t<F, ArgTypes...>;
+#else
+using invoke_result_t = typename std::result_of<F(ArgTypes...)>::type;
+#endif
 
 namespace type_traits_internal {
 

--- a/tests/btree_test.cc
+++ b/tests/btree_test.cc
@@ -1269,7 +1269,7 @@ namespace {
                       "key_compare_to_adapter should have adapted this comparator.");
         static_assert(
             std::is_same<phmap::weak_ordering,
-            phmap::result_of_t<Adapted(const K &, const K &)>>::value,
+            phmap::invoke_result_t<Adapted, const K &, const K &>>::value,
             "Adapted comparator should be a key-compare-to comparator.");
     }
     template <typename Compare, typename K>
@@ -1280,7 +1280,7 @@ namespace {
             "key_compare_to_adapter shouldn't have adapted this comparator.");
         static_assert(
             std::is_same<bool,
-            phmap::result_of_t<Unadapted(const K &, const K &)>>::value,
+            phmap::invoke_result_t<Unadapted, const K &, const K &>>::value,
             "Un-adapted comparator should return bool.");
     }
 

--- a/tests/btree_test.h
+++ b/tests/btree_test.h
@@ -440,8 +440,9 @@ namespace container_internal {
     class CountingAllocator : public std::allocator<T> {
     public:
         using Alloc = std::allocator<T>;
-        using pointer = typename Alloc::pointer;
-        using size_type = typename Alloc::size_type;
+        using AllocTraits = typename std::allocator_traits<Alloc>;
+        using pointer = typename AllocTraits::pointer;
+        using size_type = typename AllocTraits::size_type;
 
         CountingAllocator() : bytes_used_(nullptr) {}
         explicit CountingAllocator(int64_t* b) : bytes_used_(b) {}
@@ -451,14 +452,14 @@ namespace container_internal {
             : Alloc(x), bytes_used_(x.bytes_used_) {}
 
         pointer allocate(size_type n,
-                         std::allocator<void>::const_pointer hint = nullptr) {
+                         std::allocator_traits<std::allocator<void>>::const_pointer hint = nullptr) {
             assert(bytes_used_ != nullptr);
             *bytes_used_ += n * sizeof(T);
-            return Alloc::allocate(n, hint);
+            return AllocTraits::allocate(*this, n, hint);
         }
 
         void deallocate(pointer p, size_type n) {
-            Alloc::deallocate(p, n);
+            AllocTraits::deallocate(*this, p, n);
             assert(bytes_used_ != nullptr);
             *bytes_used_ -= n * sizeof(T);
         }


### PR DESCRIPTION
I was getting a lot of warnings when compiling by code so I added some checks that should also help prepare for the removal of these functions in c++20