### PR TITLE
Added Absl hash guards #50

### DIFF
--- a/parallel_hashmap/phmap_fwd_decl.h
+++ b/parallel_hashmap/phmap_fwd_decl.h
@@ -21,14 +21,14 @@
 #include <memory>
 #include <utility>
 
-#if defined(PHMAP_USE_ABSL_HASH)
+#if defined(PHMAP_USE_ABSL_HASH) && !defined(ABSL_HASH_HASH_H_)
     namespace absl { template <class T> struct Hash; };
 #endif
 
 namespace phmap {
 
 #if defined(PHMAP_USE_ABSL_HASH)
-    template <class T> using Hash = absl::Hash<T>;
+    template <class T> using Hash = ::absl::Hash<T>;
 #else
     template <class T> struct Hash;
 #endif

--- a/parallel_hashmap/phmap_utils.h
+++ b/parallel_hashmap/phmap_utils.h
@@ -33,6 +33,13 @@
 #include <tuple>
 #include "phmap_bits.h"
 
+// ---------------------------------------------------------------
+// Absl forward declaration requires global scope.
+// ---------------------------------------------------------------
+#if defined(PHMAP_USE_ABSL_HASH) && !defined(phmap_fwd_decl_h_guard_) && !defined(ABSL_HASH_HASH_H_)
+    namespace absl { template <class T> struct Hash; };
+#endif
+
 namespace phmap
 {
 
@@ -132,9 +139,8 @@ public:
 };
 
 #if defined(PHMAP_USE_ABSL_HASH) && !defined(phmap_fwd_decl_h_guard_)
-    namespace absl { template <class T> struct Hash; };
-    template <class T> using Hash = absl::Hash<T>;
-#else
+    template <class T> using Hash = ::absl::Hash<T>;
+#elif !defined(PHMAP_USE_ABSL_HASH)
 // ---------------------------------------------------------------
 //               phmap::Hash
 // ---------------------------------------------------------------


### PR DESCRIPTION
Add guards to make include order irrelevant for use with abseil hashing

With the newest version of absl, the forward declaration does _not_ seem to work. I'm not sure if it ever appropriately worked if utils is directly imported since `::phmap::absl` is declared instead of `::absl`. I fixed the potential issue in case there was a version where it does work.