### PR TITLE
Fix compile phmap failed in windows-arm64

### DIFF
--- a/examples/insert_bench.cc
+++ b/examples/insert_bench.cc
@@ -65,6 +65,7 @@ public:
         uint64_t l = umul128(operator()(), boundExcluded, &h);
         return h;
 #endif
+      return 0;
     }
 
     std::array<uint64_t, 4> state() const {

--- a/parallel_hashmap/phmap.h
+++ b/parallel_hashmap/phmap.h
@@ -1600,7 +1600,7 @@ public:
     // specific benchmarks indicating its importance.
     void prefetch_hash(size_t hash) const {
         (void)hash;
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
         auto seq = probe(hash);
         _mm_prefetch((const char *)(ctrl_ + seq.offset()), _MM_HINT_NTA);
         _mm_prefetch((const char *)(slots_ + seq.offset()), _MM_HINT_NTA);


### PR DESCRIPTION
The SSE instruction support recently added to MSVC does not detect whether it is an X86 CPU, and the arm (arm64) target will fail to compile.