### PR TITLE
fix std::shared_mutex partial template issue

### DIFF
--- a/parallel_hashmap/phmap_base.h
+++ b/parallel_hashmap/phmap_base.h
@@ -5137,6 +5137,8 @@ public:
     };
 #endif
 
+#endif // PHMAP_HAS_BOOST_THREAD_MUTEXES
+
 // --------------------------------------------------------------------------
 //         std::shared_mutex support (read and write lock support)
 // --------------------------------------------------------------------------
@@ -5157,8 +5159,6 @@ public:
         using UpgradeToUnique = typename Base::DoNothing;  // we already have unique ownership
     };
 #endif
-
-#endif // PHMAP_HAS_BOOST_THREAD_MUTEXES
 
 
 }  // phmap


### PR DESCRIPTION
Today I found when I use type:

```phmap::parallel_flat_hash_map<..., std::shared_mutex>```

Internally phmap actually has ```SharedLock``` alias to ```LockableBaseImpl::WriteLock```, then I found this macro issue.

Please reject if this is on purpose.