### PR TITLE
fix wrong function type for parallel_hash_set::lazy_emplace_with_hash

### DIFF
--- a/parallel_hashmap/phmap.h
+++ b/parallel_hashmap/phmap.h
@@ -3103,7 +3103,7 @@ public:
     }
 
     template <class K = key_type, class F>
-    iterator lazy_emplace_with_hash(size_t hashval, const key_arg<K>& key, F&& f) {
+    iterator lazy_emplace_with_hash(const key_arg<K>& key, size_t hashval, F&& f) {
         Inner& inner = sets_[subidx(hashval)];
         auto&  set   = inner.set_;
         typename Lockable::UniqueLock m(inner);


### PR DESCRIPTION
in flat_hash_set the proto type is `iterator lazy_emplace_with_hash(const key_arg<K>& key, size_t& hashval, F&& f)`.