### PR TITLE
AVX2 optimization of group lookup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Copy the parallel_hashmap directory to your project. Update your include path. T
 
 If you are using Visual Studio, you probably want to add `phmap.natvis` to your projects. This will allow for a clear display of the hash table contents in the debugger.
 
-> A cmake configuration files (CMakeLists.txt) is provided for building the tests and examples. Command for building and running the tests is: `mkdir build && cd build && cmake -DPHMAP_BUILD_TESTS=ON -DPHMAP_BUILD_EXAMPLES=ON .. && cmake --build . && make test`
+> A cmake configuration file (CMakeLists.txt) is provided for building the tests and examples.
+> * The command for building and running the tests is: `mkdir build && cd build && cmake -DPHMAP_BUILD_TESTS=ON -DPHMAP_BUILD_EXAMPLES=ON .. && cmake --build . && make test`
+> * Use this command to build tests with AVX2 support enabled: `mkdir build && cd build && cmake -DPHMAP_BUILD_TESTS=ON -DPHMAP_BUILD_EXAMPLES=ON -DCMAKE_CXX_FLAGS=-mavx2 .. && cmake --build . && make test`
 
 ## Example
 

--- a/parallel_hashmap/phmap.h
+++ b/parallel_hashmap/phmap.h
@@ -320,8 +320,10 @@ static_assert(kDeleted == -2,
 // This enables removing a branch in the hot path of find().
 // --------------------------------------------------------------------------
 inline ctrl_t* EmptyGroup() {
-  alignas(16) static constexpr ctrl_t empty_group[] = {
+  alignas(32) static constexpr ctrl_t empty_group[] = {
       kSentinel, kEmpty, kEmpty, kEmpty, kEmpty, kEmpty, kEmpty, kEmpty,
+      kEmpty,    kEmpty, kEmpty, kEmpty, kEmpty, kEmpty, kEmpty, kEmpty,
+      kEmpty,    kEmpty, kEmpty, kEmpty, kEmpty, kEmpty, kEmpty, kEmpty,
       kEmpty,    kEmpty, kEmpty, kEmpty, kEmpty, kEmpty, kEmpty, kEmpty};
   return const_cast<ctrl_t*>(empty_group);
 }
@@ -464,6 +466,101 @@ struct GroupSse2Impl
 
 #endif  // PHMAP_HAVE_SSE2
 
+#if PHMAP_HAVE_AVX2
+
+#ifdef _MSC_VER
+    #pragma warning(push)  
+    #pragma warning(disable : 4365) // conversion from 'int' to 'T', signed/unsigned mismatch
+#endif
+
+// --------------------------------------------------------------------------
+// https://github.com/abseil/abseil-cpp/issues/209
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87853
+// _mm_cmpgt_epi8 is broken under GCC with -funsigned-char
+// Work around this by using the portable implementation of Group
+// when using -funsigned-char under GCC.
+// --------------------------------------------------------------------------
+inline __m256i _mm256_cmpgt_epi8_fixed(__m256i a, __m256i b) {
+#if defined(__GNUC__) && !defined(__clang__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Woverflow"
+
+  if (std::is_unsigned<char>::value) {
+    const __m256i mask = _mm256_set1_epi8(static_cast<char>(0x80));
+    const __m256i diff = _mm256_subs_epi8(b, a);
+    return _mm256_cmpeq_epi8(_mm256_and_si256(diff, mask), mask);
+  }
+
+  #pragma GCC diagnostic pop
+#endif
+  return _mm256_cmpgt_epi8(a, b);
+}
+
+// --------------------------------------------------------------------------
+// --------------------------------------------------------------------------
+struct GroupAvx2Impl {
+    enum { kWidth = sizeof(__m256i) };  // the number of slots per group
+
+    explicit GroupAvx2Impl(const ctrl_t* pos) {
+        ctrl = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(pos));
+    }
+
+    // Returns a bitmask representing the positions of slots that match hash.
+    // ----------------------------------------------------------------------
+    BitMask<uint64_t, kWidth> Match(h2_t hash) const {
+        auto match = _mm256_set1_epi8(static_cast<char>(hash));
+        return BitMask<uint64_t, kWidth>(
+            static_cast<uint32_t>(_mm256_movemask_epi8(_mm256_cmpeq_epi8(match, ctrl))));
+    }
+
+    // Returns a bitmask representing the positions of empty slots.
+    // ------------------------------------------------------------
+    BitMask<uint64_t, kWidth> MatchEmpty() const {
+        // This only works because kEmpty is -128.
+        return BitMask<uint64_t, kWidth>(
+            static_cast<uint32_t>(_mm256_movemask_epi8(_mm256_sign_epi8(ctrl, ctrl))));
+    }
+
+#ifdef __INTEL_COMPILER
+#pragma warning push
+#pragma warning disable 68
+#endif
+    // Returns a bitmask representing the positions of empty or deleted slots.
+    // -----------------------------------------------------------------------
+    BitMask<uint64_t, kWidth> MatchEmptyOrDeleted() const {
+        auto special = _mm256_set1_epi8(static_cast<char>(kSentinel));
+        return BitMask<uint64_t, kWidth>(
+            static_cast<uint32_t>(_mm256_movemask_epi8(_mm256_cmpgt_epi8_fixed(special, ctrl))));
+    }
+
+    // Returns the number of trailing empty or deleted elements in the group.
+    // ----------------------------------------------------------------------
+    uint32_t CountLeadingEmptyOrDeleted() const {
+        auto special = _mm256_set1_epi8(static_cast<char>(kSentinel));
+        return TrailingZeros(
+            static_cast<uint32_t>(_mm256_movemask_epi8(_mm256_cmpgt_epi8_fixed(special, ctrl)) + 1));
+    }
+#ifdef __INTEL_COMPILER
+#pragma warning pop
+#endif
+
+    // ----------------------------------------------------------------------
+    void ConvertSpecialToEmptyAndFullToDeleted(ctrl_t* dst) const {
+        auto msbs = _mm256_set1_epi8(static_cast<char>(-128));
+        auto x126 = _mm256_set1_epi8(126);
+        auto res = _mm256_or_si256(_mm256_shuffle_epi8(x126, ctrl), msbs);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst), res);
+    }
+
+    __m256i ctrl;
+};
+
+#ifdef _MSC_VER
+     #pragma warning(pop)  
+#endif
+
+#endif  // PHMAP_HAVE_AVX2
+
 // --------------------------------------------------------------------------
 // --------------------------------------------------------------------------
 struct GroupPortableImpl 
@@ -519,7 +616,9 @@ struct GroupPortableImpl
     uint64_t ctrl;
 };
 
-#if PHMAP_HAVE_SSE2  
+#if PHMAP_HAVE_AVX2
+    using Group = GroupAvx2Impl;
+#elif PHMAP_HAVE_SSE2
     using Group = GroupSse2Impl;
 #else
     using Group = GroupPortableImpl;

--- a/parallel_hashmap/phmap_config.h
+++ b/parallel_hashmap/phmap_config.h
@@ -630,7 +630,7 @@
 #endif
 
 // ----------------------------------------------------------------------
-// Figure out SSE support
+// Figure out SSE/AVX support
 // ----------------------------------------------------------------------
 #ifndef PHMAP_HAVE_SSE2
     #if defined(__SSE2__) ||  \
@@ -650,6 +650,14 @@
     #endif
 #endif
 
+#ifndef PHMAP_HAVE_AVX2
+    #if defined(__AVX2__)
+        #define PHMAP_HAVE_AVX2 1
+    #else
+        #define PHMAP_HAVE_AVX2 0
+    #endif
+#endif
+
 #if PHMAP_HAVE_SSSE3 && !PHMAP_HAVE_SSE2
     #error "Bad configuration!"
 #endif
@@ -662,6 +670,9 @@
     #include <tmmintrin.h>
 #endif
 
+#if PHMAP_HAVE_AVX2
+    #include <immintrin.h>
+#endif
 
 // ----------------------------------------------------------------------
 // constexpr if

--- a/tests/raw_hash_set_test.cc
+++ b/tests/raw_hash_set_test.cc
@@ -166,7 +166,21 @@ TEST(Group, EmptyGroup) {
 }
 
 TEST(Group, Match) {
-  PHMAP_IF_CONSTEXPR (Group::kWidth == 16) {
+  PHMAP_IF_CONSTEXPR (Group::kWidth == 32) {
+    //                0       1  2         3  4       5  6          7
+    ctrl_t group[] = {kEmpty, 1, kDeleted, 3, kEmpty, 5, kSentinel, 7,
+                      7,      5, 3,        1, 1,      1, 1,         1,
+                      7,      5, 3,        1, 1,      1, 1,         1,
+                      7,      5, 3,        1, 1,      1, 1,         1};
+    EXPECT_THAT(Group{group}.Match(0), ElementsAre());
+    EXPECT_THAT(Group{group}.Match(1), ElementsAre(1,
+                                                   11, 12, 13, 14, 15,
+                                                   19, 20, 21, 22, 23,
+                                                   27, 28, 29, 30, 31));
+    EXPECT_THAT(Group{group}.Match(3), ElementsAre(3, 10, 18, 26));
+    EXPECT_THAT(Group{group}.Match(5), ElementsAre(5, 9, 17, 25));
+    EXPECT_THAT(Group{group}.Match(7), ElementsAre(7, 8, 16, 24));
+  } else PHMAP_IF_CONSTEXPR (Group::kWidth == 16) {
     ctrl_t group[] = {kEmpty, 1, kDeleted, 3, kEmpty, 5, kSentinel, 7,
                       7,      5, 3,        1, 1,      1, 1,         1};
     EXPECT_THAT(Group{group}.Match(0), ElementsAre());
@@ -185,7 +199,13 @@ TEST(Group, Match) {
 }
 
 TEST(Group, MatchEmpty) {
-  PHMAP_IF_CONSTEXPR (Group::kWidth == 16) {
+  PHMAP_IF_CONSTEXPR (Group::kWidth == 32) {
+    ctrl_t group[] = {kEmpty, 1, kDeleted, 3, kEmpty, 5, kSentinel, 7,
+                      7,      5, 3,        1, 1,      1, 1,         1,
+                      kEmpty, 1, kDeleted, 3, kEmpty, 5, kSentinel, 7,
+                      7,      5, 3,        1, 1,      1, 1,         1};
+    EXPECT_THAT(Group{group}.MatchEmpty(), ElementsAre(0, 4, 16, 20));
+  } else PHMAP_IF_CONSTEXPR (Group::kWidth == 16) {
     ctrl_t group[] = {kEmpty, 1, kDeleted, 3, kEmpty, 5, kSentinel, 7,
                       7,      5, 3,        1, 1,      1, 1,         1};
     EXPECT_THAT(Group{group}.MatchEmpty(), ElementsAre(0, 4));
@@ -198,7 +218,13 @@ TEST(Group, MatchEmpty) {
 }
 
 TEST(Group, MatchEmptyOrDeleted) {
-  PHMAP_IF_CONSTEXPR (Group::kWidth == 16) {
+  PHMAP_IF_CONSTEXPR (Group::kWidth == 32) {
+    ctrl_t group[] = {kEmpty, 1, kDeleted, 3, kEmpty, 5, kSentinel, 7,
+                      7,      5, 3,        1, 1,      1, 1,         1,
+                      kEmpty, 1, kDeleted, 3, kEmpty, 5, kSentinel, 7,
+                      7,      5, 3,        1, 1,      1, 1,         1};
+    EXPECT_THAT(Group{group}.MatchEmptyOrDeleted(), ElementsAre(0, 2, 4, 16, 18, 20));
+  } else PHMAP_IF_CONSTEXPR (Group::kWidth == 16) {
     ctrl_t group[] = {kEmpty, 1, kDeleted, 3, kEmpty, 5, kSentinel, 7,
                       7,      5, 3,        1, 1,      1, 1,         1};
     EXPECT_THAT(Group{group}.MatchEmptyOrDeleted(), ElementsAre(0, 2, 4));


### PR DESCRIPTION
Thanks for your help earlier today. We have been using your `flat_hash_map` in Merlin HugeCTR for quite some time now. I have implemented AVX2-accelerated groups for parallel-hashmap, which I hope you could absorb into the next release-version. Looking forward for your review.

```
Test project /scratch/proj/parallel-hashmap/build
      Start  1: test_compressed_tuple
 1/18 Test  #1: test_compressed_tuple ...............   Passed    0.02 sec
      Start  2: test_container_memory
 2/18 Test  #2: test_container_memory ...............   Passed    0.02 sec
      Start  3: test_hash_policy_testing
 3/18 Test  #3: test_hash_policy_testing ............   Passed    0.01 sec
      Start  4: test_node_hash_policy
 4/18 Test  #4: test_node_hash_policy ...............   Passed    0.02 sec
      Start  5: test_raw_hash_set
 5/18 Test  #5: test_raw_hash_set ...................   Passed    2.22 sec
      Start  6: test_raw_hash_set_allocator
 6/18 Test  #6: test_raw_hash_set_allocator .........   Passed    0.02 sec
      Start  7: test_flat_hash_set
 7/18 Test  #7: test_flat_hash_set ..................   Passed    0.05 sec
      Start  8: test_flat_hash_map
 8/18 Test  #8: test_flat_hash_map ..................   Passed    0.42 sec
      Start  9: test_node_hash_map
 9/18 Test  #9: test_node_hash_map ..................   Passed    0.04 sec
      Start 10: test_node_hash_set
10/18 Test #10: test_node_hash_set ..................   Passed    0.05 sec
      Start 11: test_parallel_flat_hash_map
11/18 Test #11: test_parallel_flat_hash_map .........   Passed    0.47 sec
      Start 12: test_parallel_flat_hash_set
12/18 Test #12: test_parallel_flat_hash_set .........   Passed    0.06 sec
      Start 13: test_parallel_node_hash_map
13/18 Test #13: test_parallel_node_hash_map .........   Passed    0.46 sec
      Start 14: test_parallel_node_hash_set
14/18 Test #14: test_parallel_node_hash_set .........   Passed    0.05 sec
      Start 15: test_parallel_flat_hash_map_mutex
15/18 Test #15: test_parallel_flat_hash_map_mutex ...   Passed    0.47 sec
      Start 16: test_dump_load
16/18 Test #16: test_dump_load ......................   Passed    0.03 sec
      Start 17: test_erase_if
17/18 Test #17: test_erase_if .......................   Passed    0.02 sec
      Start 18: test_btree
18/18 Test #18: test_btree ..........................   Passed   69.74 sec

100% tests passed, 0 tests failed out of 18
```

To replicate, compile with `cmake -DPHMAP_BUILD_TESTS=ON -DPHMAP_BUILD_EXAMPLES=ON -DCMAKE_CXX_FLAGS=-mavx2 ..` and run on a machine with AVX2 support.