### PR TITLE
 fix: add growth_left for dump and load, to fix the bug that when loa…

### DIFF
--- a/parallel_hashmap/phmap.h
+++ b/parallel_hashmap/phmap.h
@@ -2283,6 +2283,8 @@ private:
 
     size_t& growth_left() { return std::get<0>(settings_); }
 
+    const size_t& growth_left() const { return std::get<0>(settings_); }
+
     template <size_t N,
               template <class, class, class, class> class RefSet,
               class M, class P, class H, class E, class A>

--- a/parallel_hashmap/phmap_dump.h
+++ b/parallel_hashmap/phmap_dump.h
@@ -59,6 +59,7 @@ bool raw_hash_set<Policy, Hash, Eq, Alloc>::phmap_dump(OutputArchive& ar) const 
         return true;
     ar.saveBinary(ctrl_,  sizeof(ctrl_t) * (capacity_ + Group::kWidth + 1));
     ar.saveBinary(slots_, sizeof(slot_type) * capacity_);
+    ar.saveBinary(&growth_left(), sizeof(size_t));
     return true;
 }
 
@@ -79,6 +80,7 @@ bool raw_hash_set<Policy, Hash, Eq, Alloc>::phmap_load(InputArchive& ar) {
         return true;
     ar.loadBinary(ctrl_,  sizeof(ctrl_t) * (capacity_ + Group::kWidth + 1));
     ar.loadBinary(slots_, sizeof(slot_type) * capacity_);
+    ar.loadBinary(&growth_left(), sizeof(size_t));
     return true;
 }
 


### PR DESCRIPTION
I'm using  `phmap::parallel_flat_hash_map` from v1.35 and encountered a hang case :
- where was some insert and a lot of delete actions to the map
- dump the map to file using phmap_dump
- load from file using phmap_load
- keep inserting
- then it hangs in this while loop: https://github.com/greg7mdp/parallel-hashmap/blob/master/parallel_hashmap/phmap.h#L2197

I printed out `ctrl_` after loading and found that there is only small portion of empty slots left but a lot of delete slots, however growth_left is still large (since it was not dumped and loaded, it was set as 7/8 of the capacity - size), it never triggered `rehash_and_grow_if_necessary` after reload. So finally this map runs out of empty slots and hangs in the while loop searching for empty slot.

