### PR TITLE
remove unnecessary creation of std *_error objects

### DIFF
--- a/parallel_hashmap/phmap_base.h
+++ b/parallel_hashmap/phmap_base.h
@@ -626,7 +626,7 @@ namespace {
 #ifdef PHMAP_HAVE_EXCEPTIONS
   #define PHMAP_THROW_IMPL(e) throw e
 #else
-  #define PHMAP_THROW_IMPL(e) do { (void)(e); std::abort(); } while(0)
+  #define PHMAP_THROW_IMPL(...) std::abort()
 #endif
 }  // namespace
 


### PR DESCRIPTION
remove creation and then casting to (void) of std::*_error objects if exceptions are disabled
this also removes the need for those classes to be available to use this library