### PR TITLE
Fix C++17 detection for clang

### DIFF
--- a/parallel_hashmap/phmap_config.h
+++ b/parallel_hashmap/phmap_config.h
@@ -120,7 +120,8 @@
     #define PHMAP_HAVE_BUILTIN(x) 0
 #endif
 
-#if (!defined(__GNUC__) || __GNUC__ >= 5) && ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
+#if (!defined(__GNUC__) || defined(__clang__) || __GNUC__ >= 5) && \
+    ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
     #define PHMAP_HAVE_CC17 1
 #else
     #define PHMAP_HAVE_CC17 0


### PR DESCRIPTION
Clang (even recent, e.g. llvm 16) sets `__GNUC__` to 4, so the check for C++17 fails.

This results in the check for invoke_result_t in phmap_base.h failing, so it uses std::result_of, which is removed entirely in recent libc++, breaking the build.

```
[1/33] Building CXX object parallel-hashmap/maven/CMakeFiles/ex_basic.dir/Release/examples/basic.cc.o
FAILED: parallel-hashmap/maven/CMakeFiles/ex_basic.dir/Release/examples/basic.cc.o
ccache prefix_command=icecc /opt/clang-16.0.0/cfg/default-clang++ -DMMB_MODULE_PACKAGE=\"parallel-hashmap\" -DCMAKE_INTDIR=\"Release\" -I/home/edward.catmur/packages/parallel-hashmap/maven -g -ggdb -gdwarf-5 -Wall -Werror -Wno-unused-local-typedefs -Wno-range-loop-construct -Wno-error=deprecated-declarations -Wno-error=unused-variable -frelaxed-template-template-args -fexperimental-library -Wdeprecated-copy-with-user-provided-copy -Wdeprecated-copy-with-user-provided-dtor -Wno-error=deprecated-copy-with-user-provided-dtor -Wno-missing-braces -Wno-gnu-string-literal-operator-template -Wno-inconsistent-missing-override -Wno-braced-scalar-init -Wno-unknown-pragmas -Wno-mismatched-tags -Wno-c++11-narrowing -Wno-delete-non-abstract-non-virtual-dtor -Wno-enum-compare-switch -Wno-gnu-line-marker  -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Winit-self -Wlogical-op -Wmissing-include-dirs -Woverloaded-virtual -Wredundant-decls -Wshadow -Wstrict-null-sentinel  -Wswitch-default -Wno-unused -Wno-unknown-warning-option -Wno-gnu-zero-variadic-macro-arguments -O3 -DNDEBUG -std=c++2b -MD -MT parallel-hashmap/maven/CMakeFiles/ex_basic.dir/Release/examples/basic.cc.o -MF parallel-hashmap/maven/CMakeFiles/ex_basic.dir/Release/examples/basic.cc.o.d -o parallel-hashmap/maven/CMakeFiles/ex_basic.dir/Release/examples/basic.cc.o -c /home/edward.catmur/packages/parallel-hashmap/maven/examples/basic.cc
In file included from /home/edward.catmur/packages/parallel-hashmap/maven/examples/basic.cc:3:
In file included from /home/edward.catmur/packages/parallel-hashmap/maven/parallel_hashmap/phmap.h:121:
/home/edward.catmur/packages/parallel-hashmap/maven/parallel_hashmap/phmap_base.h:335:43: error: no type named 'result_of' in namespace 'std'
    using invoke_result_t = typename std::result_of<F(ArgTypes...)>::type;
                            ~~~~~~~~~~~~~~^~~~~~~~~
/home/edward.catmur/packages/parallel-hashmap/maven/parallel_hashmap/phmap_base.h:335:52: error: expected ';' after alias declaration
    using invoke_result_t = typename std::result_of<F(ArgTypes...)>::type;
                                                   ^
                                                   ;
2 errors generated.
```