### PR TITLE
Optimization for parallel hash map erase_if function

### DIFF
--- a/parallel_hashmap/phmap.h
+++ b/parallel_hashmap/phmap.h
@@ -3301,12 +3301,15 @@ public:
 #if __cplusplus >= 201703L
         static_assert(std::is_invocable<F, value_type&>::value);
 #endif
-        L m;
-        auto it = this->template find<K, L>(key, this->hash(key), m);
-        if (it == this->end()) return false;
+        auto hashval = this->hash(key);
+        Inner& inner = sets_[subidx(hashval)];
+        auto& set = inner.set_;
+        L m(inner);
+        auto it = set.find(key, hashval);
+        if (it == set.end()) return false;
         if (std::forward<F>(f)(const_cast<value_type &>(*it)))
         {
-            this->erase(it);
+            set._erase(it);
             return true;
         }
         return false;

--- a/tests/raw_hash_set_allocator_test.cc
+++ b/tests/raw_hash_set_allocator_test.cc
@@ -67,7 +67,7 @@ class CheckedAlloc {
       std::integral_constant<bool, (Spec & kPropagateOnSwap) != 0>;
 
   CheckedAlloc select_on_container_copy_construction() const {
-    if (Spec & kPropagateOnCopy) return *this;
+    PHMAP_IF_CONSTEXPR (Spec & kPropagateOnCopy) return *this;
     return {};
   }
 


### PR DESCRIPTION
Optimization for parallel hash map erase_if function.  Deals only with inner set iterators to avoid overhead of using parallel map iterators.

Silence a constexpr warning in allocator test