### PR TITLE
Fix : add ouput executables directory in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ endif()
 
 project(phmap VERSION ${DETECTED_PHMAP_VERSION} LANGUAGES CXX)
 
+# put all executables in a single /bin directory.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 ## ----------------------------- options -----------------------------
 option(PHMAP_INSTALL "Enable installation" ${PHMAP_MASTER_PROJECT})
 


### PR DESCRIPTION
Simple fix.
We can ouput executables into a single bin directory, just like absl.