### PR TITLE
Add access to the slot in the lazy constructor

### DIFF
--- a/parallel_hashmap/phmap.h
+++ b/parallel_hashmap/phmap.h
@@ -1506,6 +1506,10 @@ public:
         friend class raw_hash_set;
 
     public:
+        slot_type* slot() const {
+            return *slot_;
+        }
+
         template <class... Args>
         void operator()(Args&&... args) const {
             assert(*slot_);
@@ -3247,7 +3251,7 @@ public:
             set.lazy_emplace_at(offset, std::forward<F>(f));
             set.set_ctrl(offset, H2(hashval));
         }
-        return iterator_at(offset);
+        return make_iterator(&inner, set.iterator_at(offset));
     }
 
     template <class K = key_type, class F>

--- a/parallel_hashmap/phmap_base.h
+++ b/parallel_hashmap/phmap_base.h
@@ -4882,8 +4882,8 @@ public:
 
     private:
         mutex_type *m_;
-        bool        locked_shared_;
         bool        locked_;
+        bool        locked_shared_;
     };
 
     // ----------------------------------------------------


### PR DESCRIPTION
There is a specific use case where I want to cache a pointer to the newly created lazy object.  If the capacity of the map does not change between the first and second call of my function, then I use the pointer instead of repeating the lookup.

Fixed an initialization order issue in ReadWriteLock

Fix the return value of lazy_emplace and lazy_emplace_with_hash.