### PR TITLE
Fix nvcc warning about missing return statement

### DIFF
--- a/parallel_hashmap/phmap.h
+++ b/parallel_hashmap/phmap.h
@@ -210,6 +210,7 @@ uint32_t TrailingZeros(T x) {
         return base_internal::CountTrailingZerosNonZero64(static_cast<uint64_t>(x));
     else
         return base_internal::CountTrailingZerosNonZero32(static_cast<uint32_t>(x));
+    PHMAP_BUILTIN_UNREACHABLE();
 }
 
 // --------------------------------------------------------------------------

--- a/parallel_hashmap/phmap_config.h
+++ b/parallel_hashmap/phmap_config.h
@@ -651,6 +651,15 @@
 #endif
 
 // ----------------------------------------------------------------------
+// builtin unreachable
+// ----------------------------------------------------------------------
+#if PHMAP_HAVE_BUILTIN(__builtin_unreachable)
+    #define PHMAP_BUILTIN_UNREACHABLE() __builtin_unreachable()
+#else
+    #define PHMAP_BUILTIN_UNREACHABLE() (void)0
+#endif
+
+// ----------------------------------------------------------------------
 // base/macros.h
 // ----------------------------------------------------------------------
 


### PR DESCRIPTION
The fix is based on the accepted answer [here](https://stackoverflow.com/q/64523302/357257) and other answers/comments there. The builtin function `__builtin_unreachable` is supported since CUDA 11.3.