### PR TITLE
Add preprocessor macro `PHMAP_DISABLE_MIX`

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ When an ordering is not needed, a hash container is typically a better choice th
 
 - The Abseil hash tables internally randomize a hash seed, so that the table iteration order is non-deterministic. This can be useful to prevent *Denial Of Service*  attacks when a hash table is used for a customer facing web service, but it can make debugging more difficult. The *phmap* hashmaps by default do **not** implement this randomization, but it can be enabled by adding `#define PHMAP_NON_DETERMINISTIC 1` before including the header `phmap.h` (as is done in raw_hash_set_test.cc).
 
-- Unlike the Abseil hash maps, we do an internal mixing of the hash value provided. This prevents serious degradation of the hash table performance when the hash function provided by the user has poor entropy distribution. The cost in performance is very minimal, and this helps provide reliable performance even with *imperfect* hash functions.
+- Unlike the Abseil hash maps, we do an internal mixing of the hash value provided. This prevents serious degradation of the hash table performance when the hash function provided by the user has poor entropy distribution. The cost in performance is very minimal, and this helps provide reliable performance even with *imperfect* hash functions. Disabling this mixing is possible by defining the preprocessor macro `PHMAP_DISABLE_MIX=1` before `phmap.h` is included, but it is not recommended.
 
 
 ## Memory usage

--- a/parallel_hashmap/phmap.h
+++ b/parallel_hashmap/phmap.h
@@ -1892,7 +1892,11 @@ private:
     {
         template <class K, class... Args>
         size_t operator()(const K& key, Args&&...) const {
+#if PHMAP_DISABLE_MIX
+            return h(key);
+#else
             return phmap_mix<sizeof(size_t)>()(h(key));
+#endif
         }
         const hasher& h;
     };
@@ -3749,7 +3753,11 @@ private:
     {
         template <class K, class... Args>
         size_t operator()(const K& key, Args&&...) const {
+#if PHMAP_DISABLE_MIX
+            return h(key);
+#else
             return phmap_mix<sizeof(size_t)>()(h(key));
+#endif
         }
         const hasher& h;
     };


### PR DESCRIPTION
Resolves #252.

If `PHMAP_DISABLE_MIX=1` is defined before `phmap.h` is included, the internal mixing of the hash values provided by the hash function is disabled. 