### PR TITLE
Enhance the flexibility of the `BinaryOutputArchive` and `BinaryInputArchive` 

### DIFF
--- a/parallel_hashmap/phmap_dump.h
+++ b/parallel_hashmap/phmap_dump.h
@@ -1,4 +1,3 @@
-#include <functional>
 #if !defined(phmap_dump_h_guard_)
 #define phmap_dump_h_guard_
 
@@ -22,7 +21,7 @@
 
 #include <iostream>
 #include <fstream>
-#include <sstream>
+#include <functional>
 #include "phmap.h"
 namespace phmap
 {
@@ -169,8 +168,10 @@ bool parallel_hash_set<N, RefSet, Mtx_, Policy, Hash, Eq, Alloc>::phmap_load(Inp
 class BinaryOutputArchive {
 public:
     BinaryOutputArchive(const char *file_path) {
-        os_ = new std::ofstream(file_path, std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
-        destruct_ = [this]() { delete os_; };
+      os_ = new std::ofstream(file_path, std::ofstream::out |
+                                             std::ofstream::trunc |
+                                             std::ofstream::binary);
+      destruct_ = [this]() { delete os_; };
     }
 
     BinaryOutputArchive(std::ostream &os) : os_(&os) {}
@@ -203,7 +204,7 @@ public:
     }
 
 private:
-    std::ostream* os_{nullptr};
+    std::ostream* os_;
     std::function<void()> destruct_;
 };
 
@@ -246,7 +247,7 @@ public:
     }
     
 private:
-    std::istream* is_{nullptr};
+    std::istream* is_;
     std::function<void()> destruct_;
 };
 

--- a/tests/dump_load_test.cc
+++ b/tests/dump_load_test.cc
@@ -1,3 +1,7 @@
+#include <cstdint>
+#include <fstream>
+#include <parallel_hashmap/phmap.h>
+#include <sstream>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -22,6 +26,16 @@ TEST(DumpLoad, FlatHashSet_uint32) {
         EXPECT_TRUE(st2.phmap_load(ar_in));
     }
     EXPECT_TRUE(st1 == st2);
+
+    {
+        std::stringstream ss;
+        phmap::BinaryOutputArchive ar_out(ss);
+        EXPECT_TRUE(st1.phmap_dump(ar_out));
+        phmap::flat_hash_set<uint32_t> st3;
+        phmap::BinaryInputArchive ar_in(ss);
+        EXPECT_TRUE(st3.phmap_load(ar_in));
+        EXPECT_TRUE(st1 == st3);
+    }
 }
 
 TEST(DumpLoad, FlatHashMap_uint64_uint32) {
@@ -37,6 +51,16 @@ TEST(DumpLoad, FlatHashMap_uint64_uint32) {
     {
         phmap::BinaryInputArchive ar_in("./dump.data");
         EXPECT_TRUE(mp2.phmap_load(ar_in));
+    }
+
+    {
+        std::stringstream ss;
+        phmap::BinaryOutputArchive ar_out(ss);
+        EXPECT_TRUE(mp1.phmap_dump(ar_out));
+        phmap::flat_hash_map<uint64_t, uint32_t> mp3;
+        phmap::BinaryInputArchive ar_in(ss);
+        EXPECT_TRUE(mp3.phmap_load(ar_in));
+        EXPECT_TRUE(mp1 == mp3);
     }
 
     EXPECT_TRUE(mp1 == mp2);
@@ -57,6 +81,24 @@ TEST(DumpLoad, ParallelFlatHashMap_uint64_uint32) {
         EXPECT_TRUE(mp2.phmap_load(ar_in));
     }
     EXPECT_TRUE(mp1 == mp2);
+
+    // test stringstream and dump/load in the middle of the stream
+    {
+        char hello[] = "Hello";
+        std::stringstream ss;
+        ss.write(hello, 5);
+        phmap::BinaryOutputArchive ar_out(ss);
+        EXPECT_TRUE(mp1.phmap_dump(ar_out));
+        phmap::parallel_flat_hash_map<uint64_t, uint32_t> mp3;
+        phmap::BinaryInputArchive ar_in(ss);
+        char s[5];
+        ss.read(s, 5);
+        for (int i = 0; i < 5; ++i) {
+            EXPECT_EQ(hello[i], s[i]);
+        }
+        EXPECT_TRUE(mp3.phmap_load(ar_in));
+        EXPECT_TRUE(mp1 == mp3);
+    }
 }
 
 }


### PR DESCRIPTION
This pull request enhances the flexibility of the `BinaryOutputArchive` and `BinaryInputArchive` classes by enabling them to operate on a wider range of stream types. 

Currently, `BinaryOutputArchive` can only serialize a single map object to a file. This restriction prevents users from storing a combination of data types within the same file, such as a map alongside integers, floats, and strings.