### PR TITLE
Fix cstdlib include in phmap

### DIFF
--- a/parallel_hashmap/phmap_base.h
+++ b/parallel_hashmap/phmap_base.h
@@ -47,6 +47,7 @@
 #include <utility>
 #include <memory>
 #include <mutex> // for std::lock
+#include <cstdlib>
 
 #include "phmap_config.h"
 


### PR DESCRIPTION
This is a must to make it build on LLVM19.