### PR TITLE
Fix check for `arm32` so `umul` is used consistently on `gcc` and `clang` when building on `arm64`.

### DIFF
--- a/parallel_hashmap/phmap_config.h
+++ b/parallel_hashmap/phmap_config.h
@@ -182,11 +182,15 @@
 // Checks whether the __int128 compiler extension for a 128-bit
 // integral type is supported.
 // ------------------------------------------------------------
+#if defined(__arm__) && !defined(__aarch64__)
+    #define PHMAP_ARM_32
+#endif
+
 #ifdef PHMAP_HAVE_INTRINSIC_INT128
     #error PHMAP_HAVE_INTRINSIC_INT128 cannot be directly set
 #elif defined(__SIZEOF_INT128__)
-    #if (defined(__clang__) && !defined(_WIN32) && !defined(__aarch64__)) || \
-        (defined(__CUDACC__) && __CUDACC_VER_MAJOR__ >= 9) ||                \
+#if (defined(__clang__) && !defined(_WIN32) && !(defined(PHMAP_ARM_32))) || \
+        (defined(__CUDACC__) && __CUDACC_VER_MAJOR__ >= 9) ||               \
         (defined(__GNUC__) && !defined(__clang__) && !defined(__CUDACC__))
         #define PHMAP_HAVE_INTRINSIC_INT128 1
     #elif defined(__CUDACC__)


### PR DESCRIPTION
Resolves #289.