### PR TITLE
Optimize traversing empty map

### DIFF
--- a/examples/bench.cc
+++ b/examples/bench.cc
@@ -338,6 +338,21 @@ Timer _lookup(vector<T> &v, HT &hash, size_t &num_present)
 }
 
 // --------------------------------------------------------------------------
+template <class HT>
+Timer _traverse_empty(int64_t capacity, HT& hash)
+{
+    hash.clear();
+    hash.reserve(capacity);
+    Timer timer(true);
+
+    for (auto& pair : hash)
+        if (pair.second)
+            fprintf(stderr, "should not be here");
+
+    return timer;
+}
+
+// --------------------------------------------------------------------------
 template <class T, class HT>
 Timer _delete(vector<T> &v, HT &hash)
 {
@@ -440,6 +455,10 @@ int main(int argc, char ** argv)
 
             timer = _lookup(v, hash, num_present);
             //fprintf(stderr, "found %zu\n", num_present);
+        }
+        else if (!strcmp(bench_name, "traverse_empty"))
+        {
+            timer = _traverse_empty(num_keys, hash);
         }
         else if(!strcmp(bench_name, "delete"))
         {

--- a/parallel_hashmap/phmap.h
+++ b/parallel_hashmap/phmap.h
@@ -1245,6 +1245,7 @@ public:
     ~raw_hash_set() { destroy_slots(); }
 
     iterator begin() {
+        if (empty()) return end();
         auto it = iterator_at(0);
         it.skip_empty_or_deleted();
         return it;


### PR DESCRIPTION
Eliminate performance overhead in constructing `begin()` iterators on empty hash tables.

When iterating over an empty `phmap::flat_hash_map`, `begin()` unnecessarily called `skip_empty_or_deleted()` on the first bucket, causing measurable overhead.

This fix aligns with the approach already taken in Abseil: if the map is empty, simply return `end()`. See [raw_hash_set.h#L2355](https://github.com/abseil/abseil-cpp/blob/884282e28f6591d6c0680a79e07357a5aa868618/absl/container/internal/raw_hash_set.h#L2355)

**Benchmark (traversing empty map, capacity 100M, seconds):**

| `std::unordered_map` | Original `phmap::flat_hash_map` | Fixed `phmap::flat_hash_map` |
|----------------------|---------------------------------|------------------------------|
| 0.000                | 0.047                           | 0.000                        |